### PR TITLE
Refactor: changed the "template" name for "template-nfcore"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
-# ferlab/template: Changelog
+# ferlab/template-nfcore: Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## v1.0dev - [date]
 
-Initial release of ferlab/template, created with the [nf-core](https://nf-co.re/) template.
+Initial release of ferlab/template-nfcore, created with the [nf-core](https://nf-co.re/) template.
 
 ### `Added`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-**ferlab/template** is a bioinformatics pipeline that ...
+**ferlab/template-nfcore** is a bioinformatics pipeline that ...
 
 <!-- TODO nf-core:
    Complete this sentence with a 2-3 sentence summary of what types of data the pipeline ingests, a brief overview of the
@@ -29,7 +29,7 @@ Now, you can run the pipeline using:
 <!-- TODO nf-core: update the following command to include all required parameters for a minimal example -->
 
 ```bash
-nextflow run ferlab/template \
+nextflow run ferlab/template-nfcore \
    -profile <docker/singularity/.../institute> \
    --input samplesheet.csv \
    --outdir <OUTDIR>
@@ -41,7 +41,7 @@ nextflow run ferlab/template \
 
 ## Credits
 
-ferlab/template was originally written by me.
+ferlab/template-nfcore was originally written by me.
 
 We thank the following people for their extensive assistance in the development of this pipeline:
 

--- a/assets/adaptivecard.json
+++ b/assets/adaptivecard.json
@@ -17,7 +17,7 @@
                         "size": "Large",
                         "weight": "Bolder",
                         "color": "<% if (success) { %>Good<% } else { %>Attention<%} %>",
-                        "text": "ferlab/template v${version} - ${runName}",
+                        "text": "ferlab/template-nfcore v${version} - ${runName}",
                         "wrap": true
                     },
                     {

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://raw.githubusercontent.com/ferlab/template/master/assets/schema_input.json",
-    "title": "ferlab/template pipeline - params.input schema",
+    "$id": "https://raw.githubusercontent.com/ferlab/template-nfcore/master/assets/schema_input.json",
+    "title": "ferlab/template-nfcore pipeline - params.input schema",
     "description": "Schema for the file provided with params.input",
     "type": "array",
     "items": {

--- a/conf/base.config
+++ b/conf/base.config
@@ -1,6 +1,6 @@
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    ferlab/template Nextflow base config file
+    ferlab/template-nfcore Nextflow base config file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     A 'blank slate' config file, appropriate for general use on most high performance
     compute environments. Assumes that all software is installed and available on

--- a/conf/test.config
+++ b/conf/test.config
@@ -5,7 +5,7 @@
     Defines input files and everything required to run a fast and simple pipeline test.
 
     Use as follows:
-        nextflow run ferlab/template -profile test,<docker/singularity> --outdir <OUTDIR>
+        nextflow run ferlab/template-nfcore -profile test,<docker/singularity> --outdir <OUTDIR>
 
 ----------------------------------------------------------------------------------------
 */

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -5,7 +5,7 @@
     Defines input files and everything required to run a full size pipeline test.
 
     Use as follows:
-        nextflow run ferlab/template -profile test_full,<docker/singularity> --outdir <OUTDIR>
+        nextflow run ferlab/template-nfcore -profile test_full,<docker/singularity> --outdir <OUTDIR>
 
 ----------------------------------------------------------------------------------------
 */

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# ferlab/template: Documentation
+# ferlab/template-nfcore: Documentation
 
-The ferlab/template documentation is split into the following pages:
+The ferlab/template-nfcore documentation is split into the following pages:
 
 - [Usage](usage.md)
   - An overview of how the pipeline works, how to run it and a description of all of the different command-line flags.

--- a/docs/output.md
+++ b/docs/output.md
@@ -1,4 +1,4 @@
-# ferlab/template: Output
+# ferlab/template-nfcore: Output
 
 ## Introduction
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,4 +1,4 @@
-# ferlab/template: Usage
+# ferlab/template-nfcore: Usage
 
 > _Documentation of pipeline parameters is generated automatically from the pipeline schema and can no longer be found in markdown files._
 
@@ -55,7 +55,7 @@ An [example samplesheet](../assets/samplesheet.csv) has been provided with the p
 The typical command for running the pipeline is as follows:
 
 ```bash
-nextflow run ferlab/template --input ./samplesheet.csv --outdir ./results --genome GRCh37 -profile docker
+nextflow run ferlab/template-nfcore --input ./samplesheet.csv --outdir ./results --genome GRCh37 -profile docker
 ```
 
 This will launch the pipeline with the `docker` configuration profile. See below for more information about profiles.
@@ -80,7 +80,7 @@ Do not use `-c <file>` to specify parameters as this will result in errors. Cust
 The above pipeline run specified with a params file in yaml format:
 
 ```bash
-nextflow run ferlab/template -profile docker -params-file params.yaml
+nextflow run ferlab/template-nfcore -profile docker -params-file params.yaml
 ```
 
 with `params.yaml` containing:
@@ -99,14 +99,14 @@ You can also generate such `YAML`/`JSON` files via [nf-core/launch](https://nf-c
 When you run the above command, Nextflow automatically pulls the pipeline code from GitHub and stores it as a cached version. When running the pipeline after this, it will always use the cached version if available - even if the pipeline has been updated since. To make sure that you're running the latest version of the pipeline, make sure that you regularly update the cached version of the pipeline:
 
 ```bash
-nextflow pull ferlab/template
+nextflow pull ferlab/template-nfcore
 ```
 
 ### Reproducibility
 
 It is a good idea to specify a pipeline version when running the pipeline on your data. This ensures that a specific version of the pipeline code and software are used when you run your pipeline. If you keep using the same tag, you'll be running the same version of the pipeline, even if there have been changes to the code since.
 
-First, go to the [ferlab/template releases page](https://github.com/ferlab/template/releases) and find the latest pipeline version - numeric only (eg. `1.3.1`). Then specify this when running the pipeline with `-r` (one hyphen) - eg. `-r 1.3.1`. Of course, you can switch to another version by changing the number after the `-r` flag.
+First, go to the [ferlab/template-nfcore releases page](https://github.com/ferlab/template-nfcore/releases) and find the latest pipeline version - numeric only (eg. `1.3.1`). Then specify this when running the pipeline with `-r` (one hyphen) - eg. `-r 1.3.1`. Of course, you can switch to another version by changing the number after the `-r` flag.
 
 This version number will be logged in reports when you run the pipeline, so that you'll know what you used when you look back in the future. For example, at the bottom of the MultiQC reports.
 

--- a/main.nf
+++ b/main.nf
@@ -1,9 +1,9 @@
 #!/usr/bin/env nextflow
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    ferlab/template
+    ferlab/template-nfcore-nfcore
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Github : https://github.com/ferlab/template
+    Github : https://github.com/ferlab/template-nfcore
 ----------------------------------------------------------------------------------------
 */
 
@@ -15,9 +15,9 @@ nextflow.enable.dsl = 2
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-include { TEMPLATE  } from './workflows/template'
-include { PIPELINE_INITIALISATION } from './subworkflows/local/utils_nfcore_template_pipeline'
-include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_template_pipeline'
+include { TEMPLATE-NFCORE  } from './workflows/template-nfcore'
+include { PIPELINE_INITIALISATION } from './subworkflows/local/utils_nfcore_template-nfcore_pipeline'
+include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_template-nfcore_pipeline'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -28,7 +28,7 @@ include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_temp
 //
 // WORKFLOW: Run main analysis pipeline depending on type of input
 //
-workflow FERLAB_TEMPLATE {
+workflow FERLAB_TEMPLATE-NFCORE {
 
     take:
     samplesheet // channel: samplesheet read in from --input
@@ -38,12 +38,12 @@ workflow FERLAB_TEMPLATE {
     //
     // WORKFLOW: Run pipeline
     //
-    TEMPLATE (
+    TEMPLATE-NFCORE (
         samplesheet
     )
 
     emit:
-    multiqc_report = TEMPLATE.out.multiqc_report // channel: /path/to/multiqc_report.html
+    multiqc_report = TEMPLATE-NFCORE.out.multiqc_report // channel: /path/to/multiqc_report.html
 
 }
 /*
@@ -72,7 +72,7 @@ workflow {
     //
     // WORKFLOW: Run main workflow
     //
-    FERLAB_TEMPLATE (
+    FERLAB_TEMPLATE-NFCORE (
         PIPELINE_INITIALISATION.out.samplesheet
     )
 

--- a/modules.json
+++ b/modules.json
@@ -1,6 +1,6 @@
 {
-    "name": "ferlab/template",
-    "homePage": "https://github.com/ferlab/template",
+    "name": "ferlab/template-nfcore",
+    "homePage": "https://github.com/ferlab/template-nfcore",
     "repos": {
         "https://github.com/nf-core/modules.git": {
             "subworkflows": {

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,6 +1,6 @@
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    ferlab/template Nextflow config file
+    ferlab/template-nfcore Nextflow config file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     Default config options for all compute environments
 ----------------------------------------------------------------------------------------
@@ -195,9 +195,9 @@ dag {
 }
 
 manifest {
-    name            = 'ferlab/template'
+    name            = 'ferlab/template-nfcore'
     author          = """me"""
-    homePage        = 'https://github.com/ferlab/template'
+    homePage        = 'https://github.com/ferlab/template-nfcore'
     description     = """minimalist nf-core template"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/ferlab/template/master/nextflow_schema.json",
-    "title": "ferlab/template pipeline parameters",
+    "title": "ferlab/template-nfcore pipeline parameters",
     "description": "minimalist nf-core template",
     "type": "object",
     "definitions": {

--- a/subworkflows/local/utils_nfcore_template_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_template_pipeline/main.nf
@@ -1,5 +1,5 @@
 //
-// Subworkflow with functionality specific to the ferlab/template pipeline
+// Subworkflow with functionality specific to the ferlab/template-nfcore pipeline
 //
 
 /*

--- a/subworkflows/nf-core/utils_nfcore_pipeline/main.nf
+++ b/subworkflows/nf-core/utils_nfcore_pipeline/main.nf
@@ -1,5 +1,5 @@
 //
-// Subworkflow with utility functions specific to the nf-core pipeline template
+// Subworkflow with utility functions specific to the nf-core pipeline template-nfcore
 //
 
 import org.yaml.snakeyaml.Yaml

--- a/subworkflows/nf-core/utils_nfcore_pipeline/meta.yml
+++ b/subworkflows/nf-core/utils_nfcore_pipeline/meta.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
 name: "UTILS_NFCORE_PIPELINE"
-description: Subworkflow with utility functions specific to the nf-core pipeline template
+description: Subworkflow with utility functions specific to the nf-core pipeline template-nfcore
 keywords:
   - utility
   - pipeline

--- a/workflows/template-nfcore.nf
+++ b/workflows/template-nfcore.nf
@@ -6,7 +6,7 @@
 
 include { paramsSummaryMap       } from 'plugin/nf-validation'
 include { softwareVersionsToYAML } from '../subworkflows/nf-core/utils_nfcore_pipeline'
-include { methodsDescriptionText } from '../subworkflows/local/utils_nfcore_template_pipeline'
+include { methodsDescriptionText } from '../subworkflows/local/utils_nfcore_template-nfcore_pipeline'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -14,7 +14,7 @@ include { methodsDescriptionText } from '../subworkflows/local/utils_nfcore_temp
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-workflow TEMPLATE {
+workflow TEMPLATE-NFCORE {
 
     take:
     ch_samplesheet // channel: samplesheet read in from --input


### PR DESCRIPTION
This should make it less confusing to switch names when needed, replacing template-nfcore instead of "template" to reduce the risk of replacing the wrong instance of the word.